### PR TITLE
fixed destroy

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
       "aplite",
       "basalt",
       "chalk",
-      "diorite"
+      "diorite",
+      "emery"
     ],
     "resources": {
       "media": [

--- a/src/c/moon-layer.c
+++ b/src/c/moon-layer.c
@@ -101,6 +101,9 @@ Layer* moon_layer_get_layer(MoonLayer *this) {
 }
 
 void moon_layer_destroy(MoonLayer *this) {
+  MoonLayerData* data = layer_get_data(this->layer);
+  gbitmap_destroy(data->moon_bitmap);
+  gbitmap_destroy(data->current_phase_bitmap);
   layer_destroy(this->layer);
   free(this);
 }


### PR DESCRIPTION
moon_destroy() wasn't freeing gbitmaps, thus creating a memory leak
